### PR TITLE
Add pagination and tag sidebar to home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "minima", "~> 2.0"
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
    gem 'jekyll-seo-tag'
+   gem 'jekyll-paginate'
 end
 
 gem 'jekyll-admin', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       sinatra-contrib (~> 1.4)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
+    jekyll-paginate (1.1.0)
+      jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
@@ -81,6 +83,7 @@ DEPENDENCIES
   jekyll (= 3.6.3)
   jekyll-admin
   jekyll-feed (~> 0.6)
+  jekyll-paginate
   jekyll-seo-tag
   minima (~> 2.0)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,10 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-paginate
+
+paginate: 10
+paginate_path: "/page:num/"
 
 
 defaults:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,25 +6,79 @@ layout: default
 
   {{ content }}
 
-  <h1 class="page-heading">文章</h1>
+  <div class="home-layout">
+    <section class="post-feed" aria-label="文章列表">
+      <h1 class="page-heading">文章</h1>
 
-  <ul class="post-list">
-    {% for post in site.posts %}
-      <li>
-        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
+      <ul class="post-list">
+        {% assign posts_to_render = paginator.posts | default: site.posts %}
+        {% for post in posts_to_render %}
+          <li class="post-card">
+            {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+            <header class="post-card__header">
+              <time class="post-meta" datetime="{{ post.date | date_to_xmlschema }}">
+                {{ post.date | date: date_format }}
+              </time>
 
-        <h2>
-          <a class="post-link" href="{{ post.url | relative_url }}">
-            {{ post.title | escape }}
-            {% if post.is_draft %}<i class="draft-note"><small>[未发布]</small></i>{% endif %}
-          </a>
-        </h2>
+              <h2 class="post-card__title">
+                <a class="post-link" href="{{ post.url | relative_url }}">
+                  {{ post.title | escape }}
+                  {% if post.is_draft %}<i class="draft-note"><small>[未发布]</small></i>{% endif %}
+                </a>
+              </h2>
+            </header>
 
-        {{ post.excerpt }}
-      </li>
-    {% endfor %}
-  </ul>
+            <div class="post-card__excerpt">
+              {{ post.excerpt }}
+            </div>
+
+            {% if post.tags %}
+              <ul class="post-card__tags">
+                {% for tag in post.tags %}
+                  <li class="post-card__tag">{{ tag }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+
+      {% if paginator and paginator.total_pages > 1 %}
+        <nav class="pagination" aria-label="分页导航">
+          <span class="page-number">第 {{ paginator.page }} / {{ paginator.total_pages }} 页</span>
+          <div class="pagination__links">
+            {% if paginator.previous_page %}
+              <a class="pagination__link pagination__link--prev" href="{{ paginator.previous_page_path | relative_url }}">&laquo; 上一页</a>
+            {% endif %}
+            {% if paginator.next_page %}
+              <a class="pagination__link pagination__link--next" href="{{ paginator.next_page_path | relative_url }}">下一页 &raquo;</a>
+            {% endif %}
+          </div>
+        </nav>
+      {% endif %}
+    </section>
+
+    <aside class="sidebar" aria-label="站点标签">
+      <section class="tag-panel">
+        <h2 class="tag-panel__title">标签</h2>
+        {% assign sorted_tags = site.tags | sort_natural %}
+        {% if sorted_tags and sorted_tags != empty %}
+          <ul class="tag-panel__list">
+            {% for tag in sorted_tags %}
+              {% assign tag_name = tag[0] %}
+              {% assign tag_posts = tag[1] %}
+              <li class="tag-panel__item">
+                <span class="tag-panel__tag-name">{{ tag_name }}</span>
+                <span class="tag-panel__tag-count">{{ tag_posts | size }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="tag-panel__empty">暂无标签</p>
+        {% endif %}
+      </section>
+    </aside>
+  </div>
 
 
 </div>

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -225,6 +225,153 @@
   }
 }
 
+.home-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-unit;
+
+  @include media-query($on-laptop) {
+    flex-direction: column;
+  }
+}
+
+.post-feed {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.post-card {
+  background: $content-background-color;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  padding: $spacing-unit * 0.75;
+  transition: box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-within {
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+  }
+}
+
+.post-card__header {
+  margin-bottom: $spacing-unit * 0.35;
+}
+
+.post-card__title {
+  margin: $spacing-unit * 0.2 0 0;
+}
+
+.post-card__excerpt {
+  color: $grey-color-dark;
+}
+
+.post-card__tags {
+  margin: $spacing-unit * 0.5 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.post-card__tag {
+  background: lighten($layout-bg-color, 32%);
+  border-radius: 999px;
+  color: $layout-font-color;
+  font-size: $small-font-size;
+  line-height: 1;
+  padding: 6px 10px;
+}
+
+.sidebar {
+  flex: 0 0 240px;
+
+  @include media-query($on-laptop) {
+    width: 100%;
+  }
+}
+
+.tag-panel {
+  background: $content-background-color;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  padding: $spacing-unit * 0.75;
+  width: 100%;
+}
+
+.tag-panel__title {
+  margin-top: 0;
+  margin-bottom: $spacing-unit * 0.5;
+}
+
+.tag-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.tag-panel__item {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  background: lighten($layout-bg-color, 36%);
+  border-radius: 4px;
+  color: $layout-font-color;
+  font-size: $small-font-size;
+  padding: 6px 10px;
+}
+
+.tag-panel__tag-name {
+  font-weight: $large-font-weight;
+}
+
+.tag-panel__tag-count {
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.tag-panel__empty {
+  color: $grey-color;
+  font-size: $small-font-size;
+  margin: 0;
+}
+
+.pagination {
+  align-items: center;
+  background: $content-background-color;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: $spacing-unit;
+  padding: $spacing-unit * 0.5 $spacing-unit * 0.75;
+}
+
+.page-number {
+  color: $grey-color;
+  font-size: $small-font-size;
+}
+
+.pagination__links {
+  display: flex;
+  gap: 12px;
+}
+
+.pagination__link {
+  color: $link-color;
+  font-weight: $large-font-weight;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
 .post-meta {
   font-size: $small-font-size;
   color: $grey-color;


### PR DESCRIPTION
## Summary
- enable Jekyll pagination with a 10-post page size and update dependencies
- redesign the home layout to show paginated post cards with publication dates and tag chips
- add a sidebar tag panel and companion styles for the new layout and pagination controls

## Testing
- bundle install *(fails: 403 Forbidden while fetching rubygems.org index)*
- bundle exec jekyll serve --livereload *(fails: bundler cannot find jekyll executable without bundle install)*

------
https://chatgpt.com/codex/tasks/task_b_68ee0b2862c08331b6334fe56723526b