### PR TITLE
Remove jekyll-admin plugin to eliminate vulnerable Sinatra dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :jekyll_plugins do
    gem 'jekyll-paginate'
 end
 
-gem 'jekyll-admin', group: :jekyll_plugins
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    backports (3.21.0)
     colorator (1.1.0)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
@@ -18,10 +17,6 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 3)
       safe_yaml (~> 1.0)
-    jekyll-admin (0.9.0)
-      jekyll (>= 3.3, < 5.0)
-      sinatra (~> 1.4)
-      sinatra-contrib (~> 1.4)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
     jekyll-paginate (1.1.0)
@@ -42,15 +37,9 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    multi_json (1.15.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    rack (1.6.13)
-    rack-protection (1.5.5)
-      rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -61,18 +50,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.7)
-      backports (>= 2.0)
-      multi_json
-      rack-protection
-      rack-test
-      sinatra (~> 1.4.0)
-      tilt (>= 1.3, < 3)
-    tilt (2.0.10)
 
 PLATFORMS
   universal-darwin-20
@@ -81,7 +58,6 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.6.3)
-  jekyll-admin
   jekyll-feed (~> 0.6)
   jekyll-paginate
   jekyll-seo-tag


### PR DESCRIPTION
## Summary
- remove the optional jekyll-admin plugin so the site no longer pulls in the vulnerable sinatra gem
- clean the lockfile to drop jekyll-admin and its transitive sinatra dependencies

## Testing
- bundle install *(fails: rubygems.org returns 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ee1fae9c548331841bbf7595f2ec40